### PR TITLE
[Package] Fix Limit API. Fix go vet complaints.

### DIFF
--- a/wasmedge/limit.go
+++ b/wasmedge/limit.go
@@ -9,34 +9,16 @@ type Limit struct {
 	hasmax bool
 }
 
-func NewLimit(vals ...interface{}) Limit {
-	self := Limit{
-		min:    0,
-		max:    0,
+func NewLimit(minVal uint) *Limit {
+	l := &Limit{
+		min:    minVal,
 		hasmax: false,
 	}
-	if len(vals) == 0 || len(vals) > 2 {
-		panic("Wrong argument of NewLimit(), parameter length must be 0 or 1")
-	}
+	return l
+}
 
-	switch vals[0].(type) {
-	case int, int32, int64, uint, uint32, uint64:
-		self.min = vals[0].(uint)
-	default:
-		panic("Wrong argument of NewLimit(), parameter types must be integer")
-	}
-
-	if len(vals) == 2 {
-		switch vals[0].(type) {
-		case int, int32, int64, uint, uint32, uint64:
-			self.max = vals[0].(uint)
-			self.hasmax = true
-		default:
-			panic("Wrong argument of NewLimit(), parameter types must be integer")
-		}
-		if self.max < self.min {
-			panic("Wrong argument of NewLimit(), max value should be greater or equal to min value")
-		}
-	}
-	return self
+func (l *Limit) WithMaxVal(maxVal uint) *Limit {
+	l.hasmax = true
+	l.max = maxVal
+	return l
 }

--- a/wasmedge/limit_test.go
+++ b/wasmedge/limit_test.go
@@ -1,0 +1,22 @@
+package wasmedge
+
+import "testing"
+
+const (
+	minVal = 1024
+)
+
+func TestNewLimit(t *testing.T) {
+	l := NewLimit(minVal)
+	if l.min != minVal {
+		t.Fatal("wrong min value")
+	}
+	if l.hasmax {
+		t.Fatal("should have no max value")
+	}
+
+	l.WithMaxVal(minVal * 2)
+	if !l.hasmax {
+		t.Fatal("should have max value")
+	}
+}

--- a/wasmedge/memory.go
+++ b/wasmedge/memory.go
@@ -8,7 +8,7 @@ type Memory struct {
 	_inner *C.WasmEdge_MemoryInstanceContext
 }
 
-func NewMemory(lim Limit) *Memory {
+func NewMemory(lim *Limit) *Memory {
 	climit := C.WasmEdge_Limit{HasMax: C.bool(lim.hasmax), Min: C.uint32_t(lim.min), Max: C.uint32_t(lim.max)}
 	self := &Memory{
 		_inner: C.WasmEdge_MemoryInstanceCreate(climit),

--- a/wasmedge/table.go
+++ b/wasmedge/table.go
@@ -7,7 +7,7 @@ type Table struct {
 	_inner *C.WasmEdge_TableInstanceContext
 }
 
-func NewTable(rtype RefType, lim Limit) *Table {
+func NewTable(rtype RefType, lim *Limit) *Table {
 	climit := C.WasmEdge_Limit{HasMax: C.bool(lim.hasmax), Min: C.uint32_t(lim.min), Max: C.uint32_t(lim.max)}
 	crtype := C.enum_WasmEdge_RefType(rtype)
 	self := &Table{

--- a/wasmedge/value.go
+++ b/wasmedge/value.go
@@ -248,7 +248,6 @@ func fromWasmEdgeValue(value C.WasmEdge_Value, origtype C.enum_WasmEdge_ValType)
 	default:
 		panic("Wrong argument of fromWasmEdgeValue()")
 	}
-	return 0
 }
 
 func toWasmEdgeValueSlide(vals ...interface{}) []C.WasmEdge_Value {
@@ -340,7 +339,7 @@ func toWasmEdgeValueSlideBindgen(vm *VM, retarray bool, modname *string, vals ..
 			}
 			mem.SetData(val.([]byte), uint(rets[0].(int32)), uint(mallocsize))
 		default:
-			errorString := fmt.Sprintf("Wrong argument of toWasmEdgeValueSlideBindgen(): {} not supported", t)
+			errorString := fmt.Sprintf("Wrong argument of toWasmEdgeValueSlideBindgen(): %T not supported", t)
 			panic(errorString)
 		}
 	}
@@ -443,5 +442,4 @@ func fromWasmEdgeValueSlideBindgen(vm *VM, rettype bindgen, modname *string, cva
 	default:
 		panic("Wrong expected return type")
 	}
-	return nil, nil
 }


### PR DESCRIPTION
1. The NewLimit API has wrong implementation and is not idiomatic in Go, this commit brings a simple impl.
2. Fix some go vet complaints.